### PR TITLE
cooperate-region-batchにおける性能劣化 issue/#11

### DIFF
--- a/src/repositories/EntityOperation.ts
+++ b/src/repositories/EntityOperation.ts
@@ -39,7 +39,8 @@ export default class EntityOperation {
         fromDate: Date,
         operatorId: number,
         operatorType: number,
-        toBlockCode: number
+        toBlockCode: number,
+        category: number
     ): Promise<Notification[]> {
         const connection = getConnection('postgres');
         const sendFromMe = isSend
@@ -98,6 +99,9 @@ export default class EntityOperation {
                         'readingManagement.id IS NULL'
                     );
                 }
+                if (category) {
+                    entities.andWhere('notification.category_catalog_code = :categoryCatalogCode', { categoryCatalogCode: category });
+                }
                 entities.limit(num > 0 ? num : null)
                     .orderBy('notification.id', 'DESC');
 
@@ -131,6 +135,9 @@ export default class EntityOperation {
                     entities.andWhere(
                         'readingManagement.id IS NULL'
                     );
+                }
+                if (category) {
+                    entities.andWhere('notification.category_catalog_code = :category', { category: category });
                 }
                 entities.limit(num > 0 ? num : null)
                     .orderBy('notification.id', 'DESC');

--- a/src/resources/dto/GetNotificationReqDto.ts
+++ b/src/resources/dto/GetNotificationReqDto.ts
@@ -9,7 +9,9 @@ import {
     IsDate,
     IsBoolean,
     IsOptional,
-    IsDefined
+    IsDefined,
+    Max,
+    Min
 } from 'class-validator';
 import { transformToBooleanFromString, transformToNumber, transformToDate } from '../../common/Transform';
 /* eslint-enable */
@@ -62,4 +64,12 @@ export default class GetNotificationReqDto {
     @IsOptional()
     @IsDate()
         to: Date;
+
+    /** カテゴリーカタログコード */
+    @Transform(({ value }) => { return transformToNumber(value); })
+    @Max(Number.MAX_SAFE_INTEGER)
+    @Min(1)
+    @IsNumber()
+    @IsOptional()
+        category: number;
 }

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -123,7 +123,7 @@ export default class NotificationService {
         const entities = await EntityOperation.takeNotification(
             dto.type, dto.isSend, dto.isUnread, dto.isApproval,
             dto.num, dto.to, dto.from, operator.operatorId, operator.type,
-            operator.blockCode);
+            operator.blockCode, dto.category);
         if (entities.length <= 0) {
             throw new AppError(Message.NOT_EXISTS_NOTIFICATION, 204);
         }

--- a/src/tests/AbnormalNotification.service.spec.ts
+++ b/src/tests/AbnormalNotification.service.spec.ts
@@ -30,7 +30,7 @@ describe('Notification Service API', () => {
     // テストが全て終了したら実行される事後処理
     afterAll(async () => {
         // アプリケーションの停止
-        Application.stop()
+        Application.stop();
         // スタブサーバーの停止
         await transferServer.stop();
         await catalogServer.stop();

--- a/src/tests/Notificatioin.approval.spec.ts
+++ b/src/tests/Notificatioin.approval.spec.ts
@@ -118,7 +118,7 @@ describe('Notification Service API', () => {
         // テーブルをクリア
         await clearTables();
         // アプリケーションの停止
-        Application.stop()
+        Application.stop();
         // スタブサーバーの停止
         await operatorServer.stop();
         await approvalServer.stop();

--- a/src/tests/Notification.add.spec.ts
+++ b/src/tests/Notification.add.spec.ts
@@ -49,7 +49,7 @@ describe('Notification Service API', () => {
     // テストが全て終了したら実行される事後処理
     afterAll(async () => {
         // アプリケーションの停止
-        Application.stop()
+        Application.stop();
     });
 
     // POSTメソッドのAPIテスト

--- a/src/tests/Notification.read.spec.ts
+++ b/src/tests/Notification.read.spec.ts
@@ -55,7 +55,7 @@ describe('Notification Service API', () => {
         // テーブルをクリア
         await clearTables();
         // アプリケーションの停止
-        Application.stop()
+        Application.stop();
         // スタブサーバーの停止
         await operatorServer.stop();
     });
@@ -133,7 +133,7 @@ describe('Notification Service API', () => {
         // テーブルをクリア
         await clearTables();
         // アプリケーションの停止
-        Application.stop()
+        Application.stop();
         // スタブサーバーの停止
         await operatorServer.stop();
     });

--- a/src/tests/Notification.transfer.spec.ts
+++ b/src/tests/Notification.transfer.spec.ts
@@ -50,7 +50,7 @@ describe('Notification Service API', () => {
     // テストが全て終了したら実行される事後処理
     afterAll(async () => {
         // アプリケーションの停止
-        Application.stop()
+        Application.stop();
     });
 
     // POSTメソッドのAPIテスト

--- a/src/tests/Notification.validator.spec.ts
+++ b/src/tests/Notification.validator.spec.ts
@@ -22,7 +22,7 @@ describe('Notification Service API', () => {
     // テストがすべて終了したら実行される事後処理
     afterAll(async () => {
         // アプリケーションの停止
-        Application.stop()
+        Application.stop();
     });
 
     // POSTメソッドのAPIテスト

--- a/src/tests/xDatabase.ts
+++ b/src/tests/xDatabase.ts
@@ -98,7 +98,6 @@ export default class DatabaseUtility {
     }
 }
 
-
 /**
  * データベースに引数の内容で通知を登録する
  * @param params: [type, from_block_catalog_code, from_application_catalog_code, from_workflow_catalog_code, from_operator_id, to_block_catalog_code, to_operator_type, is_send_all, is_transfer]
@@ -132,6 +131,50 @@ export async function notificationInsert (params: (string | number | boolean)[])
         ) VALUES (
             $1, $2, $3, $4, $5, $6, $7, $8, $9,
             'Test', 'Test notice record', null, now(), false, 'tester', now(), 'tester', now(), 1, 1, 1, 1
+        )
+        RETURNING id
+    `;
+    await database.connect();
+    const result = await database.query(query, params);
+    await database.close();
+    return parseInt(result.rows[0].id);
+}
+
+/**
+ * カテゴリーを指定して通知を登録する
+ * @param params: [type, from_block_catalog_code, from_application_catalog_code, from_workflow_catalog_code, from_operator_id, to_block_catalog_code, to_operator_type, is_send_all, is_transfer, category_catalog_code]
+ */
+export async function notificationCategoryInsert (params: (string | number | boolean)[]): Promise<number> {
+    const database = new DatabaseUtility();
+    const query = `
+        INSERT INTO ${database.getSchemaName()}.notification (
+            type,
+            from_block_catalog_code,
+            from_application_catalog_code,
+            from_workflow_catalog_code,
+            from_operator_id,
+            to_block_catalog_code,
+            to_operator_type,
+            is_send_all,
+            is_transfer,
+            title,
+            content,
+            attributes,
+            send_at,
+            is_disabled,
+            created_by,
+            created_at,
+            updated_by,
+            updated_at,
+            category_catalog_code,
+            category_catalog_version,
+            from_actor_code,
+            from_actor_version
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9,
+            'Test', 'Test notice record', null, now(), false, 'tester', now(), 'tester', now(),
+            $10,
+            1, 1, 1
         )
         RETURNING id
     `;


### PR DESCRIPTION
coopereate-region-batch内で処理に不要な通知情報も取得している。
不要な通知処理が多くなると性能劣化に繋がるため、処理に不要なレコードは取得しないようにする。

fixes #11 
## UT環境
~~~
$ node --version
v18.20.5

$ psql -U postgres -d pxr_pod -p 5432 -h localhost -c "SELECT version();"
                                                        version                                                        
-----------------------------------------------------------------------------------------------------------------------
 PostgreSQL 15.10 (Debian 15.10-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
(1 row)

## UT実行結果
$ npm run test:unit

> notification-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

 PASS  src/tests/Notification.validator.spec.ts
 PASS  src/tests/Notification.add.spec.ts
 PASS  src/tests/Notificatioin.approval.spec.ts
 PASS  src/tests/AbnormalNotification.service.spec.ts
 PASS  src/tests/Notification.list.spec.ts
 PASS  src/tests/Notification.read.spec.ts
 PASS  src/tests/Notification.transfer.spec.ts
 PASS  src/tests/AbnormalServices.spec.ts
------------------------------|---------|----------|---------|---------|-------------------
File                          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------------------|---------|----------|---------|---------|-------------------
All files                     |   99.86 |    99.43 |     100 |   99.85 |                   
 domains                      |     100 |      100 |     100 |     100 |                   
  OperatorDomain.ts           |     100 |      100 |     100 |     100 |                   
  ProxyRequestDomain.ts       |     100 |      100 |     100 |     100 |                   
 repositories                 |   98.46 |    95.45 |     100 |   98.46 |                   
  EntityOperation.ts          |   98.46 |    95.45 |     100 |   98.46 | 103               
 repositories/postgres        |     100 |      100 |     100 |     100 |                   
  ApprovalManaged.ts          |     100 |      100 |     100 |     100 |                   
  Notification.ts             |     100 |      100 |     100 |     100 |                   
  NotificationDestination.ts  |     100 |      100 |     100 |     100 |                   
  ReadFlagManagement.ts       |     100 |      100 |     100 |     100 |                   
 resources                    |     100 |      100 |     100 |     100 |                   
  ApprovalController.ts       |     100 |      100 |     100 |     100 |                   
  NotificationController.ts   |     100 |      100 |     100 |     100 |                   
  ReadController.ts           |     100 |      100 |     100 |     100 |                   
  TransferController.ts       |     100 |      100 |     100 |     100 |                   
 resources/dto                |     100 |      100 |     100 |     100 |                   
  AddNotificationReqDto.ts    |     100 |      100 |     100 |     100 |                   
  AddNotificationResDto.ts    |     100 |      100 |     100 |     100 |                   
  GetNotificationReqDto.ts    |     100 |      100 |     100 |     100 |                   
  PutApprovalReqDto.ts        |     100 |      100 |     100 |     100 |                   
  ReadNotificationReqDto.ts   |     100 |      100 |     100 |     100 |                   
  ReadNotificationResDto.ts   |     100 |      100 |     100 |     100 |                   
 resources/validator          |     100 |      100 |     100 |     100 |                   
  AddRequestValidator.ts      |     100 |      100 |     100 |     100 |                   
  ApprovalRequestValidator.ts |     100 |      100 |     100 |     100 |                   
  GetRequestValidator.ts      |     100 |      100 |     100 |     100 |                   
  ReadRequestValidator.ts     |     100 |      100 |     100 |     100 |                   
 services                     |     100 |      100 |     100 |     100 |                   
  ApprovalService.ts          |     100 |      100 |     100 |     100 |                   
  BookManageService.ts        |     100 |      100 |     100 |     100 |                   
  CatalogService.ts           |     100 |      100 |     100 |     100 |                   
  NotificationService.ts      |     100 |      100 |     100 |     100 |                   
  OperatorService.ts          |     100 |      100 |     100 |     100 |                   
  ProxyService.ts             |     100 |      100 |     100 |     100 |                   
------------------------------|---------|----------|---------|---------|-------------------

Test Suites: 8 passed, 8 total
Tests:       86 passed, 86 total
Snapshots:   0 total
Time:        6.768 s, estimated 8 s
Ran all test suites.